### PR TITLE
Refactor: Update ranged attack logic to use Chebyshev distance

### DIFF
--- a/script.js
+++ b/script.js
@@ -276,7 +276,7 @@ function selectPiece(row, col) {
                 // Allow attacks only within a square (Manhattan distance) for now for simplicity with Attack_Range
                 // This means Attack_Range = 1 is adjacent squares (including diagonals)
                 // Attack_Range = 2 is squares up to 2 units away, etc.
-                if (Math.abs(r_offset) + Math.abs(c_offset) > pieceDefinition.Attack_Range) continue;
+                // if (Math.abs(r_offset) + Math.abs(c_offset) > pieceDefinition.Attack_Range) continue;
 
 
                 const targetRow = row + r_offset;


### PR DESCRIPTION
The ranged attack calculation in `selectPiece` function in `script.js` was modified. The previous implementation used Manhattan distance (`Math.abs(r_offset) + Math.abs(c_offset) > pieceDefinition.Attack_Range)`), resulting in a diamond-shaped attack area.

This commit comments out the Manhattan distance check, effectively changing the attack pattern to use Chebyshev distance. This allows pieces with ranged attacks (e.g., Archer) to target any square within their `Attack_Range` in a square area, including diagonals, as per your requirement.

Testing confirmed that an Archer with Attack_Range: 3 can now target all squares in a 7x7 grid around it.